### PR TITLE
Bug : fix require approval condetion

### DIFF
--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PublishConfigData" remoteFilesAllowedToDisappearOnAutoupload="false">
+    <serverData>
+      <paths name="Local or mounted folder">
+        <serverdata>
+          <mappings>
+            <mapping local="$PROJECT_DIR$" web="/" />
+          </mappings>
+        </serverdata>
+      </paths>
+    </serverData>
+  </component>
+</project>

--- a/src/Traits/RequiresApproval.php
+++ b/src/Traits/RequiresApproval.php
@@ -95,7 +95,7 @@ trait RequiresApproval
      */
     protected function requiresApprovalWhen($modifications): bool
     {
-        if(app()->runningInConsole() == true && $this->disableApprovalWhenRunningInConsole == true){
+        if(app()->runningInConsole() == true || $this->disableApprovalWhenRunningInConsole == true){
             return false;
         }
         return true;


### PR DESCRIPTION
when using the method : 
```
    public function requiresApprovalWhen(array $modifications): bool
    {
        return false;
    }
    
```

inside the model that has the trait `RequiresApproval` the normal behavior is to ignore the approval requirement. but due to the modification in the function : 
```
    protected function requiresApprovalWhen($modifications): bool
    {
        if(app()->runningInConsole() == true && $this->disableApprovalWhenRunningInConsole == true){
            return false;
        }
        return true;
    }
  
  ```  
  
  It will always return `true` as the `app()->runningInConsole()` returns false.